### PR TITLE
fix: powerstation thermite

### DIFF
--- a/client/powerstation.lua
+++ b/client/powerstation.lua
@@ -39,7 +39,9 @@ end)
 RegisterNetEvent('thermite:UseThermite', function()
     local pos = GetEntityCoords(cache.ped)
     if closestStation ~= 0 then
-        if math.random(1, 100) > 85 or qbx.isWearingGloves() then return end
+        if math.random(1, 100) < 85 or not qbx.isWearingGloves() then
+            TriggerServerEvent('evidence:server:CreateFingerDrop', pos)
+        end
         TriggerServerEvent('evidence:server:CreateFingerDrop', pos)
         local dist = #(pos - powerStationConfig[closestStation].coords)
         if dist < 1.5 then
@@ -60,7 +62,9 @@ RegisterNetEvent('thermite:UseThermite', function()
             end
         end
     elseif CurrentThermiteGate ~= 0 then
-        if math.random(1, 100) > 85 or qbx.isWearingGloves() then return end
+        if math.random(1, 100) < 85 or not qbx.isWearingGloves() then
+            TriggerServerEvent('evidence:server:CreateFingerDrop', pos)
+        end
         TriggerServerEvent('evidence:server:CreateFingerDrop', pos)
         if CurrentCops >= config.minThermitePolice then
             currentGate = CurrentThermiteGate


### PR DESCRIPTION
oh no, normal if statements are horrible i need to use a guard clause 😱

Fingerprint drop logic is a guard clause that will return before giving the player a chance to complete the minigame and light the thermite.
I just 69'd the logic so it works yippee

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions. yeah probably idk
